### PR TITLE
Fix vertical datum code

### DIFF
--- a/src/ifc-spf/geolocation-ifc2x3.ifc
+++ b/src/ifc-spf/geolocation-ifc2x3.ifc
@@ -31,7 +31,7 @@ DATA;
 #24=IFCOBJECTIVE('Beauty','The built form should be beautiful',.HARD.,$,$,$,$,$,$,.DESIGNINTENT.,$);
 #25=IFCOBJECTIVE('Safety','No facilities exist to generate killer artificial intelligence',.HARD.,$,$,$,$,$,$,.HEALTHANDSAFETY.,$);
 #26=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:7856'),$);
-#27=IFCPROPERTYSINGLEVALUE('VerticalDatum',$,IFCIDENTIFIER('EPSG:5111'),$);
+#27=IFCPROPERTYSINGLEVALUE('VerticalDatum',$,IFCIDENTIFIER('EPSG:5711'),$);
 #28=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCIDENTIFIER('METRE'),$);
 #29=IFCPROPERTYSET('1UvkckG31D$f5JAKi2o_1C',#20,'EPset_ProjectedCRS',$,(#26,#27,#28));
 #30=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(334871.85),$);

--- a/src/ifc-spf/geolocation-ifc4.ifc
+++ b/src/ifc-spf/geolocation-ifc4.ifc
@@ -31,7 +31,7 @@ DATA;
 #24=IFCOBJECTIVE('Beauty','The built form should be beautiful',.HARD.,$,$,$,$,$,$,.DESIGNINTENT.,$);
 #25=IFCOBJECTIVE('Safety','No facilities exist to generate killer artificial intelligence',.HARD.,$,$,$,$,$,$,.HEALTHANDSAFETY.,$);
 #26=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
-#27=IFCPROJECTEDCRS('EPSG:7856','','','EPSG:5111','','',#26);
+#27=IFCPROJECTEDCRS('EPSG:7856','','','EPSG:5711','','',#26);
 #28=IFCMAPCONVERSION(#21,#27,334871.85,6252295.02,12.,2.59808,-1.5,1.);
 #29=IFCCARTESIANPOINT((-1.,0.,-1.));
 #30=IFCCARTESIANPOINT((1.,0.,1.));


### PR DESCRIPTION
Files `geolocation-ifc2x3.ifc` and `geolocation-ifc2x3.ifc` have a typo in vertical datum code: existing code [EPSG:5111](https://epsg.org/crs_5111/ETRS89-NTM-zone-11.html) defines projected CRS somewhere in Norway. I assume original intention was to specify AHD datum, which has EPSG code 5711. 